### PR TITLE
fix: Scan release asset labels to discover helm chart

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq -r --arg var "$EVENT" '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<< '${{github.event}}'
+          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<$GITHUB_CONTEXT
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -8,10 +8,10 @@ inputs:
     description: 'Release tag to fetch chart from'
     required: false
     default: ${{ github.event.release.tag_name }}
-  release-asset-name:
-    description: 'the asset name containing the chart, must be a tar file'
+  release-asset-label-contains:
+    description: 'Release asset label to scan for. Release assets are scanned by lower casing the label and using a jq contains() check. The default value is `helm chart`, if your release assets are labeled differently, specify your label here'
     required: false
-    default: 'chart.tgz'
+    default: 'helm chart'
   chart-repository:
     description: 'The git repository to upload the chart to'
     required: false
@@ -43,15 +43,15 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        if [ ! -f ${{ inputs.release-asset-name }} ]; then
-          echo "The input asset does not exist after downloading from releases"
+        assetName=$(echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${inputs.release-asset-label-contains}")) | .name')
+        if [ ! -f $assetName ]; then
+          echo "Failed to find a release asset matching the configured label"
           exit 1
         fi
-        if [[ "${{ inputs.release-asset-name }}" == "chart.tgz" ]]; then
-          tar -zxvf ${{ inputs.release-asset-name }} && rm ${{ inputs.release-asset-name }}
-        fi
-        helm repo index .
-    - name: Commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: "Automation - Added new helm chart to repository"
+        tar -zxvf $assetName && rm $assetName
+        ls -l
+#        helm repo index .
+#    - name: Commit changes
+#      uses: stefanzweifel/git-auto-commit-action@v4
+#      with:
+#        commit_message: "Automation - Added new helm chart to repository"

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Scan for asset name from release
+      uses: sergeysova/jq-action@v2
+      id: assetName
+      with:
+        cmd: |
+          jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
+    - name: Verify asset name
+      shell: bash
+      run: |
+        echo "asset name is  ${{ steps.assetName.outputs.value }}"
+        if [ -z ${{ steps.assetName.outputs.value }} ]; then
+          echo "Failed to find a release asset matching the configured label"
+          exit 1
+        fi
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
@@ -40,35 +54,11 @@ runs:
         tag: ${{ inputs.tag }}
         fileName: ${{ inputs.release-asset-name }}
         token: ${{ inputs.token }}
-    - name: Test jq
-      uses: sergeysova/jq-action@v2
-      id: event
-      with:
-        cmd: |
-          jq '.' <<<${{toJSON(github.event.release.assets)}}
-    - name: Show event
-      shell: bash
-      run: |
-        echo "event  is  ${{ steps.event.outputs.value }}"
-    - name: Extract version from package.json
-      uses: sergeysova/jq-action@v2
-      id: assetName
-      with:
-        cmd: |
-          jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
-    - name: Show assetName
-      shell: bash
-      run: |
-        echo "asset name is  ${{ steps.assetName.outputs.value }}"
-        if [ -z ${{ steps.assetName.outputs.value }}" ]; then
-          echo "Failed to find a release asset matching the configured label"
-          exit 1
-        fi
     - name: Upload chart and reindex
       shell: bash
       run: |
         tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
-        ls -l $assetName
+        ls -l ${{ steps.assetName.outputs.value }}
 #        helm repo index .
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yaml
+++ b/action.yaml
@@ -30,9 +30,10 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
-        echo "asset name is $assetName"
+        echo '${{github.event.release.assets}} | jq '.'
+#        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+#        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+#        echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo ${{github.event.release.assets}} | jq '.'
+        echo ${{toJSON(github.event.release.assets)}} | jq '.'
 #        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
 #        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
 #        echo "asset name is $assetName"

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo ${{toJSON(github.event.release.assets)}} | jq '.'
+        echo '${{toJSON(github.event.release.assets)}}' | jq '.'
 #        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
 #        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
 #        echo "asset name is $assetName"

--- a/action.yaml
+++ b/action.yaml
@@ -54,13 +54,14 @@ runs:
       with:
         repository: ${{ github.repository }}
         tag: ${{ inputs.tag }}
-        fileName: ${{ steps.assetName.outputs.value }}
+        fileName: "*"
+        out-file-path: "release-chart"
         token: ${{ inputs.token }}
     - name: Upload chart and reindex
       shell: bash
       run: |
-        ls -l
-        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
+        ls -l $GITHUB_WORKSPACE/release-chart
+        tar -zxvf $GITHUB_WORKSPACE/release-chart/${{ steps.assetName.outputs.value }}
         ls -l ${{ steps.assetName.outputs.value }}
 #        helm repo index .
 #    - name: Commit changes

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.' <<<${{toJSON(github.event.release.assets)}}
+          jq '.' <<<'${{toJSON(github.event.release.assets)}}'
 #          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
     - name: Verify asset name
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,9 @@ runs:
       uses: stefanprodan/kube-tools@v1
       with:
         command: |
-          echo '${{github.event.release.assets}} | jq '.[]'
+          echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+          assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+          echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -23,14 +23,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-#        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
-    - name: Scan for asset name from release
+    - name: Scan for asset name from release based on asset labels
       uses: sergeysova/jq-action@v2
       id: assetName
       with:
         cmd: |
-          jq -r '.[0].name' <<<'${{toJSON(github.event.release.assets)}}'
-#          jq -r '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
+          jq -r '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Verify asset name
       shell: bash
       run: |
@@ -56,12 +54,11 @@ runs:
         tag: ${{ inputs.tag }}
         fileName: ${{ steps.assetName.outputs.value }}
         token: ${{ inputs.token }}
-    - name: Upload chart and reindex
+    - name: Reindex to include downloaded chart
       shell: bash
       run: |
         helm repo index .
-        git diff
-#    - name: Commit changes
-#      uses: stefanzweifel/git-auto-commit-action@v4
-#      with:
-#        commit_message: "Automation - Added new helm chart to repository"
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "Automation - Added new helm chart to repository"

--- a/action.yaml
+++ b/action.yaml
@@ -30,8 +30,8 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo 'json assets is ${{toJSON(github.event.release.assets)}}'
-        jq '.' <<<'${{toJSON(github.event.release.assets)}}'
+        assetName=$(jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
+        echo "assetName is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,8 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
+          jq '.' <<<${{toJSON(github.event.release.assets)}}
+#          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
     - name: Verify asset name
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{github.event.release.assets}} | jq '.'
+        echo ${{github.event.release.assets}} | jq '.'
 #        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
 #        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
 #        echo "asset name is $assetName"

--- a/action.yaml
+++ b/action.yaml
@@ -30,10 +30,10 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{toJSON(github.event.release.assets)}}' | jq '.'
-#        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-#        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
-#        echo "asset name is $assetName"
+#        echo '${{toJSON(github.event.release.assets)}}' | jq '.'
+        echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,7 @@ runs:
       with:
         cmd: |
           jq '.[0].name' <<<'${{toJSON(github.event.release.assets)}}'
+#          jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Verify asset name
       shell: bash
       run: |
@@ -38,28 +39,28 @@ runs:
           echo "Failed to find a release asset matching the configured label"
           exit 1
         fi
-#    - name: Install Helm
-#      uses: azure/setup-helm@v1
-#      with:
-#        version: v3.7.2
-#    - name: Clone charts repository
-#      uses: actions/checkout@v2
-#      with:
-#        token: ${{ inputs.token }}
-#        repository: ${{ inputs.chart-repository }}
-#        ref: ${{ inputs.chart-repository-ref }}
-#    - name: Fetch release
-#      uses: robinraju/release-downloader@v1.3
-#      with:
-#        repository: ${{ github.repository }}
-#        tag: ${{ inputs.tag }}
-#        fileName: ${{ inputs.release-asset-name }}
-#        token: ${{ inputs.token }}
-#    - name: Upload chart and reindex
-#      shell: bash
-#      run: |
-#        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
-#        ls -l ${{ steps.assetName.outputs.value }}
+    - name: Install Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.7.2
+    - name: Clone charts repository
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.token }}
+        repository: ${{ inputs.chart-repository }}
+        ref: ${{ inputs.chart-repository-ref }}
+    - name: Fetch release
+      uses: robinraju/release-downloader@v1.3
+      with:
+        repository: ${{ github.repository }}
+        tag: ${{ inputs.tag }}
+        fileName: ${{ inputs.release-asset-name }}
+        token: ${{ inputs.token }}
+    - name: Upload chart and reindex
+      shell: bash
+      run: |
+        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
+        ls -l ${{ steps.assetName.outputs.value }}
 #        helm repo index .
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,7 @@ runs:
       with:
         repository: ${{ github.repository }}
         tag: ${{ inputs.tag }}
-        fileName: ${{ inputs.release-asset-name }}
+        fileName: ${{ steps.assetName.outputs.value }}
         token: ${{ inputs.token }}
     - name: Upload chart and reindex
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,6 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-#        echo '${{toJSON(github.event.release.assets)}}' | jq '.'
         echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
         assetName=$(echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq -r --arg var "$GITHUB_CONTEXT" '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<"$GITHUB_CONTEXT"
+          jq -r --arg var "$EVENT" '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<< ${{github.event}}
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -30,8 +30,10 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{github.event.release.assets}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo '${{github.event.release.assets}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo ${{toJSON(github.event.release.assets}}) | jq '.'
+        echo ${{toJSON(github.event.release.assets}}) | jq '.[]'
+        echo ${{toJSON(github.event.release.assets}}) | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo ${{toJSON(github.event.release.assets}}) | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -30,8 +30,8 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo '${{toJSON(github.event.release.assets)}}' | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo '${{toJSON(github.event.release.assets)}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo '${{toJSON(github.event.release.assets)}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: event
       with:
         cmd: |
-          jq '.event.release.assets' <<<${{toJSON(github.event.release.assets)}}
+          jq '.' <<<${{toJSON(github.event.release.assets)}}
     - name: Show event
       shell: bash
       run: |
@@ -55,7 +55,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
+          jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
       uses: stefanprodan/kube-tools@v1
       with:
         command: |
-          echo '${{github.event.release.assets}} | jq '.'
+          echo '${{github.event.release.assets}} | jq '.[]'
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
+          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
     - name: Verify asset name
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: event
       with:
         cmd: |
-          jq '.event' <<<$GITHUB_CONTEXT
+          jq '.' <<<${{github}}
     - name: Show event
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        assetName=$(jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
+        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
         echo "assetName is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -59,6 +59,7 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
+        ls -l
         tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
         ls -l ${{ steps.assetName.outputs.value }}
 #        helm repo index .

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        - echo 'json assets is ${{toJSON(github.event.release.assets)}}'
+        echo 'json assets is ${{toJSON(github.event.release.assets)}}'
         jq '.' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -54,15 +54,13 @@ runs:
       with:
         repository: ${{ github.repository }}
         tag: ${{ inputs.tag }}
-        fileName: "*"
-        out-file-path: "release-chart"
+        fileName: ${{ steps.assetName.outputs.value }}
         token: ${{ inputs.token }}
     - name: Upload chart and reindex
       shell: bash
       run: |
-        ls -l $GITHUB_WORKSPACE/release-chart
-        tar -zxvf $GITHUB_WORKSPACE/release-chart/${{ steps.assetName.outputs.value }}
-        ls -l ${{ steps.assetName.outputs.value }}
+        tar -zxvf ${{ steps.assetName.outputs.value }}
+        ls -l
 #        helm repo index .
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
+        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<$GITHUB_CONTEXT
         echo "assetName is $assetName"
 #    - name: Scan for asset name from release
 #      uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -59,9 +59,10 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        tar -zxvf ${{ steps.assetName.outputs.value }}
-        ls -l
-#        helm repo index .
+#        tar -zxvf ${{ steps.assetName.outputs.value }}
+#        ls -l
+        helm repo index .
+        git status
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4
 #      with:

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,9 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<$GITHUB_CONTEXT
+        assets='${{toJSON(github.event.release.assets)}}'
+        echo "assets is $assets"
+        jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<$assets
         echo "assetName is $assetName"
 #    - name: Scan for asset name from release
 #      uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -59,8 +59,6 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-#        tar -zxvf ${{ steps.assetName.outputs.value }}
-#        ls -l
         helm repo index .
         git status
 #    - name: Commit changes

--- a/action.yaml
+++ b/action.yaml
@@ -43,8 +43,8 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        echo ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo '${{github.event}}' | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo '${{github.event}}' | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
         if [ -z "$assetName" ]; then
           echo "Failed to find a release asset matching the configured label"

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,16 @@ runs:
         tag: ${{ inputs.tag }}
         fileName: ${{ inputs.release-asset-name }}
         token: ${{ inputs.token }}
+    - name: Test jq
+      uses: sergeysova/jq-action@v2
+      id: event
+      with:
+        cmd: |
+          jq '.event' <<<$GITHUB_CONTEXT
+    - name: Show event
+      shell: bash
+      run: |
+        echo "event  is  ${{ steps.event.outputs.value }}"
     - name: Extract version from package.json
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,11 @@ runs:
   using: "composite"
   steps:
     - name: Scan for asset name from release
+      uses: stefanprodan/kube-tools@v1
+      with:
+        command: |
+          echo '${{github.event.release.assets}} | jq '.'
+    - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -40,17 +40,24 @@ runs:
         tag: ${{ inputs.tag }}
         fileName: ${{ inputs.release-asset-name }}
         token: ${{ inputs.token }}
-    - name: Upload chart and reindex
+    - name: Extract version from package.json
+      uses: sergeysova/jq-action@v2
+      id: assetName
+      with:
+        cmd: |
+          ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+    - name: Show assetName
       shell: bash
       run: |
-        ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
-        echo "asset name is $assetName"
-        if [ -z "$assetName" ]; then
+        echo "asset name is  ${{ steps.assetName.outputs.value }}"
+        if [ -z ${{ steps.assetName.outputs.value }}" ]; then
           echo "Failed to find a release asset matching the configured label"
           exit 1
         fi
-        tar -zxvf $assetName && rm $assetName
+    - name: Upload chart and reindex
+      shell: bash
+      run: |
+        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
         ls -l $assetName
 #        helm repo index .
 #    - name: Commit changes

--- a/action.yaml
+++ b/action.yaml
@@ -30,10 +30,9 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        assets='${{toJSON(github.event.release.assets)}}'
-        echo "assets is $assets"
-        jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<$assets
+        assetName=$(jq '.[0].name' <<<'${{toJSON(github.event.release.assets)}}')
         echo "assetName is $assetName"
+#        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
 #    - name: Scan for asset name from release
 #      uses: sergeysova/jq-action@v2
 #      id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: event
       with:
         cmd: |
-          jq '.event.release.assets' <<<${{toJSON(github)}}
+          jq '.event.release.assets' <<<${{toJSON(github.event.release.assets)}}
     - name: Show event
       shell: bash
       run: |
@@ -55,7 +55,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github)}}
+          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq -r --arg var "$EVENT" '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<< ${{github.event}}
+          jq -r --arg var "$EVENT" '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<< '${{github.event}}'
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -23,13 +23,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Scan for asset name from release
-      uses: stefanprodan/kube-tools@v1
+    - name: Install jq
+      uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        command: |
-          echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-          assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
-          echo "asset name is $assetName"
+        packages: jq
+    - name: Scan for asset name from release
+      shell: bash
+      run: |
+        echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo '${{github.event.release.assets}} | jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+          jq -r --arg var "$GITHUB_CONTEXT" '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<"$GITHUB_CONTEXT"
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -30,45 +30,45 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
+        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
         echo "assetName is $assetName"
-    - name: Scan for asset name from release
-      uses: sergeysova/jq-action@v2
-      id: assetName
-      with:
-        cmd: |
-          jq '.' <<<'${{toJSON(github.event.release.assets)}}'
+#    - name: Scan for asset name from release
+#      uses: sergeysova/jq-action@v2
+#      id: assetName
+#      with:
+#        cmd: |
+#          jq '.' <<<'${{toJSON(github.event.release.assets)}}'
 #          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
-    - name: Verify asset name
-      shell: bash
-      run: |
-        echo "asset name is  ${{ steps.assetName.outputs.value }}"
-        if [ -z ${{ steps.assetName.outputs.value }} ]; then
-          echo "Failed to find a release asset matching the configured label"
-          exit 1
-        fi
-    - name: Install Helm
-      uses: azure/setup-helm@v1
-      with:
-        version: v3.7.2
-    - name: Clone charts repository
-      uses: actions/checkout@v2
-      with:
-        token: ${{ inputs.token }}
-        repository: ${{ inputs.chart-repository }}
-        ref: ${{ inputs.chart-repository-ref }}
-    - name: Fetch release
-      uses: robinraju/release-downloader@v1.3
-      with:
-        repository: ${{ github.repository }}
-        tag: ${{ inputs.tag }}
-        fileName: ${{ inputs.release-asset-name }}
-        token: ${{ inputs.token }}
-    - name: Upload chart and reindex
-      shell: bash
-      run: |
-        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
-        ls -l ${{ steps.assetName.outputs.value }}
+#    - name: Verify asset name
+#      shell: bash
+#      run: |
+#        echo "asset name is  ${{ steps.assetName.outputs.value }}"
+#        if [ -z ${{ steps.assetName.outputs.value }} ]; then
+#          echo "Failed to find a release asset matching the configured label"
+#          exit 1
+#        fi
+#    - name: Install Helm
+#      uses: azure/setup-helm@v1
+#      with:
+#        version: v3.7.2
+#    - name: Clone charts repository
+#      uses: actions/checkout@v2
+#      with:
+#        token: ${{ inputs.token }}
+#        repository: ${{ inputs.chart-repository }}
+#        ref: ${{ inputs.chart-repository-ref }}
+#    - name: Fetch release
+#      uses: robinraju/release-downloader@v1.3
+#      with:
+#        repository: ${{ github.repository }}
+#        tag: ${{ inputs.tag }}
+#        fileName: ${{ inputs.release-asset-name }}
+#        token: ${{ inputs.token }}
+#    - name: Upload chart and reindex
+#      shell: bash
+#      run: |
+#        tar -zxvf ${{ steps.assetName.outputs.value }} && rm ${{ steps.assetName.outputs.value }}
+#        ls -l ${{ steps.assetName.outputs.value }}
 #        helm repo index .
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yaml
+++ b/action.yaml
@@ -30,8 +30,8 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo '${{toJSON(github.event.release.assets)}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo '${{toJSON(github.event.release.assets)}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo '${{github.event.release.assets}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo '${{github.event.release.assets}}' | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2

--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,7 @@ runs:
       shell: bash
       run: |
         helm repo index .
-        git status
+        git diff
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4
 #      with:

--- a/action.yaml
+++ b/action.yaml
@@ -23,31 +23,21 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install jq
-      uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        packages: jq
+#        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
     - name: Scan for asset name from release
+      uses: sergeysova/jq-action@v2
+      id: assetName
+      with:
+        cmd: |
+          jq '.[0].name' <<<'${{toJSON(github.event.release.assets)}}'
+    - name: Verify asset name
       shell: bash
       run: |
-        assetName=$(jq '.[0].name' <<<'${{toJSON(github.event.release.assets)}}')
-        echo "assetName is $assetName"
-#        assetName=$(jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}')
-#    - name: Scan for asset name from release
-#      uses: sergeysova/jq-action@v2
-#      id: assetName
-#      with:
-#        cmd: |
-#          jq '.' <<<'${{toJSON(github.event.release.assets)}}'
-#          jq '. | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github.event.release.assets)}}
-#    - name: Verify asset name
-#      shell: bash
-#      run: |
-#        echo "asset name is  ${{ steps.assetName.outputs.value }}"
-#        if [ -z ${{ steps.assetName.outputs.value }} ]; then
-#          echo "Failed to find a release asset matching the configured label"
-#          exit 1
-#        fi
+        echo "asset name is  ${{ steps.assetName.outputs.value }}"
+        if [ -z ${{ steps.assetName.outputs.value }} ]; then
+          echo "Failed to find a release asset matching the configured label"
+          exit 1
+        fi
 #    - name: Install Helm
 #      uses: azure/setup-helm@v1
 #      with:

--- a/action.yaml
+++ b/action.yaml
@@ -44,6 +44,7 @@ runs:
       shell: bash
       run: |
         assetName=$(echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${inputs.release-asset-label-contains}")) | .name')
+        echo "asset name is $assetName"
         if [ ! -f $assetName ]; then
           echo "Failed to find a release asset matching the configured label"
           exit 1

--- a/action.yaml
+++ b/action.yaml
@@ -43,14 +43,15 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        assetName=$(echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${inputs.release-asset-label-contains}")) | .name')
+        echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
         if [ ! -f $assetName ]; then
           echo "Failed to find a release asset matching the configured label"
           exit 1
         fi
         tar -zxvf $assetName && rm $assetName
-        ls -l
+        ls -l $assetName
 #        helm repo index .
 #    - name: Commit changes
 #      uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yaml
+++ b/action.yaml
@@ -30,11 +30,8 @@ runs:
     - name: Scan for asset name from release
       shell: bash
       run: |
-        echo ${{toJSON(github.event.release.assets}}) | jq '.'
-        echo ${{toJSON(github.event.release.assets}}) | jq '.[]'
-        echo ${{toJSON(github.event.release.assets}}) | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo ${{toJSON(github.event.release.assets}}) | jq '.[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
-        echo "asset name is $assetName"
+        - echo 'json assets is ${{toJSON(github.event.release.assets)}}'
+        jq '.' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Scan for asset name from release
       uses: sergeysova/jq-action@v2
       id: assetName

--- a/action.yaml
+++ b/action.yaml
@@ -43,10 +43,10 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo $GITHUB_CONTEXT | jq -c '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        echo ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(echo ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
-        if [ ! -f $assetName ]; then
+        if [ -z "$assetName" ]; then
           echo "Failed to find a release asset matching the configured label"
           exit 1
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: event
       with:
         cmd: |
-          jq '.' <<<${{github}}
+          jq '.' <<<${{toJSON(github)}}
     - name: Show event
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -29,8 +29,8 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.[0].name' <<<'${{toJSON(github.event.release.assets)}}'
-#          jq '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
+          jq -r '.[0].name' <<<'${{toJSON(github.event.release.assets)}}'
+#          jq -r '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Verify asset name
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       id: event
       with:
         cmd: |
-          jq '.' <<<${{toJSON(github)}}
+          jq '.event.release.assets' <<<${{toJSON(github)}}
     - name: Show event
       shell: bash
       run: |
@@ -55,7 +55,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<$GITHUB_CONTEXT
+          jq '.event.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name' <<<${{toJSON(github)}}
     - name: Show assetName
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -43,8 +43,8 @@ runs:
     - name: Upload chart and reindex
       shell: bash
       run: |
-        echo '${{github.event}}' | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
-        assetName=$(echo '${{github.event}}' | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
+        ${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name'
+        assetName=$(${{github.event}} | jq -c '.release.assets[] | select(.label | ascii_downcase | contains("${{inputs.release-asset-label-contains}}")) | .name')
         echo "asset name is $assetName"
         if [ -z "$assetName" ]; then
           echo "Failed to find a release asset matching the configured label"


### PR DESCRIPTION
This PR changes the functionality of the action to scan release assets for a configurable label, and uses the discovered file name to download the file, which should be a .tgz file from `helm package`