### PR TITLE
fix: use the release-asset-label-contains input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
       id: assetName
       with:
         cmd: |
-          jq -r '.[] | select(.label | ascii_downcase | contains("helm chart")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
+          jq -r '.[] | select(.label | ascii_downcase | contains("${{ inputs.release-asset-label-contains }}")) | .name' <<<'${{toJSON(github.event.release.assets)}}'
     - name: Verify asset name
       shell: bash
       run: |


### PR DESCRIPTION
Currently it doesn't do anything, and I wanna use it.